### PR TITLE
clean up isofate imports

### DIFF
--- a/isofate/atmodeller_coupler.py
+++ b/isofate/atmodeller_coupler.py
@@ -14,9 +14,9 @@ from atmodeller.solubility import get_solubility_models
 solubility_models = get_solubility_models()
 
 #isofate imports
-from IsoFATE.isofate..constants import *
-from IsoFATE.isofate..orbit_params import *
-from IsoFATE.isofate..isofunks import *
+from isofate.constants import *
+from isofate.orbit_params import *
+from isofate.isofunks import *
 
 #other imports
 import numpy as np

--- a/isofate/isofunks.py
+++ b/isofate/isofunks.py
@@ -27,8 +27,8 @@ from scipy.interpolate import RegularGridInterpolator as RGI
 # from atmodeller.utilities import earth_oceans_to_kg
 
 # import imports
-from IsoFATE.isofate.constants import *
-from IsoFATE.isofate.orbit_params import *
+from isofate.constants import *
+from isofate.orbit_params import *
 
 # incident XUV flux
 

--- a/isofate/isoplot.py
+++ b/isofate/isoplot.py
@@ -1,7 +1,7 @@
 import matplotlib.pyplot as plt
 import numpy as np
-from IsoFATE.isofate.isofunks import *
-import IsoFATE.isofate.constants as const
+from isofate.isofunks import *
+import isofate.constants as const
 
 def isoplot(sol,n_atmodeller,Mp,f_atm,Fp,T,M_star,d):
 

--- a/isofate/orbit_params.py
+++ b/isofate/orbit_params.py
@@ -5,7 +5,7 @@ Miscellaneous functions for planetary orbital parameters
 '''
 
 import numpy as np
-from IsoFATE.isofate.constants import *
+from isofate.constants import *
 
 def Luminosity(R, T):
     '''

--- a/isofate/sim.py
+++ b/isofate/sim.py
@@ -9,15 +9,15 @@ import time as TIME
 
 import matplotlib.pyplot as plt
 
-from IsoFATE.isofate.constants import *
+from isofate.constants import *
 
 # from debug_isofate_coupler_v2 import *
-from IsoFATE.isofate.isofate_coupler import *
+from isofate.isofate_coupler import *
 
 # from isofate_coupler_v3 import *
 # from isofate_coupler_v3_cannon import *
-from IsoFATE.isofate.isofunks import *
-from IsoFATE.isofate.orbit_params import *
+from isofate.isofunks import *
+from isofate.orbit_params import *
 
 start = TIME.time()
 

--- a/isofate/test_Fxuv.py
+++ b/isofate/test_Fxuv.py
@@ -1,4 +1,4 @@
-from IsoFATE.isofate.isofunks import Fxuv
+from isofate.isofunks import Fxuv
 
 '''
 Test script for Fxuv function

--- a/isofate/test_isocalc.py
+++ b/isofate/test_isocalc.py
@@ -1,4 +1,4 @@
-from IsoFATE.isofate.isofunks import isocalc
+from isofate.isofunks import isocalc
 
 '''
 Test script for isocalc function

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "isofate"
-version = "0.0.6"
+version = "0.0.9"
 requires-python = ">=3.11"
 
 dependencies = [

--- a/uv.lock
+++ b/uv.lock
@@ -704,7 +704,7 @@ wheels = [
 
 [[package]]
 name = "isofate"
-version = "0.0.6"
+version = "0.0.9"
 source = { editable = "." }
 dependencies = [
     { name = "atmodeller" },


### PR DESCRIPTION
## Change Description 
removed `IsoFATE.` from import statements to resolve import error 

## How it was Validated
tested with local pip install of changes
<img width="976" height="93" alt="image" src="https://github.com/user-attachments/assets/adee5685-0165-472f-939f-0429097dbcd7" />

successfully ran `Fxuv` 
<img width="443" height="179" alt="image" src="https://github.com/user-attachments/assets/629eed70-74c7-421b-a205-81bf8cd71911" />
